### PR TITLE
Support --branch as well as --tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ output/
 .cache/
 dist/
 
-# Preferences file
+# Just there for testing
 com.github.gkluoe.git2jss.plist
+_jss

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 Git2JSS
 ===============================
 
-Version : v1.0.0
+Version : v1.1.0rc1
 
 Author: Geoff Lee
 
@@ -14,6 +14,8 @@ Overview
 **Answer:** *Make it zero-effort.*
 
 Using *Git2jss*, after making changes to JSS Scripts or CEAs in your dev/test environment and pushing them to a Git repository, you can export a tagged copy to your JSS, complete with the Git changelog in the 'Notes' field. Reverting a change is as easy as exporting the previous tagged version.
+
+You can also use this script in a Continuous Integration pipeline to export scripts from the head of a given branch to your JSS.
 
 Templating of some important values is also supported, so your scripts automatically contain details of the last change, and where they can be found in source control.
 
@@ -61,14 +63,16 @@ Commandline
 
 You can use it on the commandine like this::
 
-  # Create a new tag, v1.0.1, and export my_great_script.py to a script object of the same name on the JSS
-  
-  $ git2jss --file my_great_script.py --create --tag v1.0.1
-
   # Export the file localscript.sh to a Script object on the JSS called do_something_great.sh
   # using the existing tag v0.0.9
   
+  $ git tag v0.0.9 && git push origin v0.0.9
   $ git2jss --file localscript.sh --name do_something_great.sh --tag v0.0.9
+  
+  # Export the file run-softwareupdate.py at the head of the master branch
+  # to an object on the JSS with the same name
+  
+  $ git2jss --file run-softwareupdate.py --branch master
 
   # Export the file check_firewall.sh to a ComputerExtensionAttribute object on the JSS called 
   # FirewallCheck, using the existing tag v0.0.9
@@ -79,6 +83,10 @@ You can use it on the commandine like this::
   # with a matching name, and exists at tag v1.0.2
   
   $ git2jss --all --tag v1.0.2
+  
+  # Or do the same for all files at the head of branch 'production'
+  
+  $ git2jss --all --branch production
 
   # Show information about the currently configured JSS (or enter details if none configured)
   
@@ -89,24 +97,25 @@ Templating
 
 The following variables, if embedded into your script, will be replaced with the indicated values when being transferred to the JSS
 
-+--------------+---------------------------------------------------------------------+
-| Variable     | Value                                                               | 
-+==============+=====================================================================+
-| ``@@VERSION``| The name of the git tag that you have specified (eg v1.0.1)         |
-+--------------+---------------------------------------------------------------------+
-| ``@@ORIGIN`` | Assuming you have a git remote called 'origin', the URL thereof     |
-|              | (eg https://github.com/uoe-macos/jss)                               |
-+--------------+---------------------------------------------------------------------+
-| ``@@PATH``   | The name of the file in the git repository identified by @@ORIGIN`` |
-+--------------+---------------------------------------------------------------------+
-| ``@@DATE``   | The date of the *last change* of the file in Git                    |
-+--------------+---------------------------------------------------------------------+
-| ``@@USER``   | The username used by git2jss to authenticate to the JSS at          |
-|              | the time the script was exported                                    |
-+--------------+---------------------------------------------------------------------+
-| ``@@LOG``    | The entire Git log for this script, formatted thus:                 |
-|              | ``'%h - %cD %ce: %n %s%n'``                                         |
-+--------------+---------------------------------------------------------------------+
++--------------+-------------------------------------------------------------------------------------------------+
+| Variable     | Value                                                                                           | 
++==============+=================================================================================================+
+| ``@@VERSION``| If --tag was used: The name of the git tag that you have specified (eg v1.0.1)                  |
+|              | If --branch was used: The commit hash of the last change of the file, and a note of the branch  |
++--------------+-------------------------------------------------------------------------------------------------+
+| ``@@ORIGIN`` | Assuming you have a git remote called 'origin', the URL thereof                                 |
+|              | (eg https://github.com/uoe-macos/jss)                                                           |
++--------------+-------------------------------------------------------------------------------------------------+
+| ``@@PATH``   | The name of the file in the git repository identified by @@ORIGIN``                             |
++--------------+-------------------------------------------------------------------------------------------------+
+| ``@@DATE``   | The date of the *last change* of the file in Git                                                |
++--------------+-------------------------------------------------------------------------------------------------+
+| ``@@USER``   | The username used by git2jss to authenticate to the JSS at                                      |
+|              | the time the script was exported                                                                |
++--------------+-------------------------------------------------------------------------------------------------+
+| ``@@LOG``    | The entire Git log for this script, formatted thus:                                             |
+|              | ``'%h - %cD %ce: %n %s%n'``                                                                     |
++--------------+-------------------------------------------------------------------------------------------------+
 
 ``@@LOG`` is used to construct the 'Notes' field in the JSS, overwriting anything that was present previously.
 

--- a/git2jss/__init__.py
+++ b/git2jss/__init__.py
@@ -77,7 +77,7 @@ def _get_args(argv=None):
                         help="Show information about the currently configured JSS")
 
     parser.add_argument('--tag', metavar='TAG', type=str, default=None,
-                        help=('Name of the tag on the git remote to operate from.' 
+                        help=('Name of the tag on the git remote to operate from.'
                               'The tag must have been pushed to origin: '
                               'locally committed tags will not be accepted.'))
 
@@ -119,9 +119,9 @@ def _get_args(argv=None):
         options.target_name = None
 
     # Unless we've only been asked for JSS info, we need a tag or branch to do anything
-    if not options.jss_info and ( not (options.branch or options.tag) ):
-        parser.error(
-            "Which tag or branch HEAD do you want to push? Please specify with '--tag' or '--branch'")
+    if not options.jss_info and (not (options.branch or options.tag)):
+        parser.error(("Which tag or branch HEAD do you want to push?"
+                      "Please specify with '--tag' or '--branch'"))
 
     # Can't specify --branch and --tag
     if options.branch and options.tag:

--- a/git2jss/__init__.py
+++ b/git2jss/__init__.py
@@ -69,16 +69,22 @@ def _get_args(argv=None):
 
     parser = argparse.ArgumentParser(usage=('git2jss [-i --jss-info] [-h] [ --mode MODE ] '
                                             '[--create]  [ --no-keychain] [--all | --file FILE '
-                                            '[ --name NAME ] ]  --tag TAG'),
+                                            '[ --name NAME ] ]  [ --tag TAG | --branch BRANCH ]'),
                                      version=VERSION, description=DESCRIPTION, epilog=EPILOG,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument('-i', '--jss-info', action='store_true', dest='jss_info',
                         help="Show information about the currently configured JSS")
 
-    parser.add_argument('--tag', metavar='TAG', type=str, default=False,
-                        help=('Name of the TAG in Git. The tag must have been pushed to origin: '
+    parser.add_argument('--tag', metavar='TAG', type=str, default=None,
+                        help=('Name of the tag on the git remote to operate from.' 
+                              'The tag must have been pushed to origin: '
                               'locally committed tags will not be accepted.'))
+
+    parser.add_argument('--branch', metavar='BRANCH', type=str, default=None,
+                        help=('An branch on the git remote operate from.'
+                              'eg: develop'
+                              'The HEAD of the branch will be checked out and operated on'))
 
     parser.add_argument('--mode', metavar='MODE', type=str, choices=PROCESSORS,
                         dest='mode', default='Script',
@@ -90,9 +96,6 @@ def _get_args(argv=None):
     parser.add_argument('--name', metavar='NAME', dest='target_name', type=str, default=None,
                         help=('Name of the target object in the JSS (if omitted, it is assumed '
                               'that the target object has a name exactly matching FILE)'))
-
-    parser.add_argument('--create', action='store_true', default=False, dest='create_tag',
-                        help="If TAG doesn't exist, then create it and push to the server")
 
     parser.add_argument('--no-keychain', action='store_true', default=False, dest='no_keychain',
                         help=('Do not store authentication credentials in the system keychain.\n'
@@ -115,10 +118,15 @@ def _get_args(argv=None):
         print("WARNING: --all was specified so ignoring --name option")
         options.target_name = None
 
-    # Unless we've only been asked for JSS info, we need a tag to do anything
-    if not options.jss_info and not options.tag:
+    # Unless we've only been asked for JSS info, we need a tag or branch to do anything
+    if not options.jss_info and ( not (options.branch or options.tag) ):
         parser.error(
-            "Which tag do you want to push? Please specify with '--tag'")
+            "Which tag or branch HEAD do you want to push? Please specify with '--tag' or '--branch'")
+
+    # Can't specify --branch and --tag
+    if options.branch and options.tag:
+        parser.error(
+            "Please specify --branch or --tag, but not both!")
 
     # We need to know which files to operate on!
     if options.tag and not (options.source_file or options.push_all):
@@ -149,7 +157,7 @@ def main(argv=None, prefs_file=None):
         print_jss_info(jss_prefs)
         sys.exit(0)
 
-    _repo = GitRepo(tag=options.tag, create=options.create_tag)
+    _repo = GitRepo(tag=options.tag, branch=options.branch)
 
     try:
         if options.push_all:

--- a/git2jss/vcs.py
+++ b/git2jss/vcs.py
@@ -91,8 +91,8 @@ class GitRepo(object):
             self._clone_to_tmp()
         else:
             raise RefNotFoundError("Ref doesn't exist on git remote {}: {}"
-                                       .format(self.remote_url, self.ref))
-                
+                                   .format(self.remote_url, self.ref))
+
     def __del__(self):
         """ Called when there are 0 references left to this
         object. try to delete our temporary directory.
@@ -165,7 +165,7 @@ class GitRepo(object):
         commit = subprocess.check_output(["git", "log",
                                           "-1", "--format=%H",
                                           filename], cwd=self.tmp_dir).strip()
-        
+
         return '{} on branch: {}'.format(commit, self.branch)
 
     def file_info(self, filename):
@@ -221,8 +221,8 @@ class GitRepo(object):
         return handle
 
     def _has_ref_on_remote(self, r_name):
-        """ Check whether a reference `r_name` exists in 
-        the current repo 
+        """ Check whether a reference `r_name` exists in
+        the current repo
         :rtype: True or false.
         """
         # Get refs from the git remote
@@ -234,4 +234,4 @@ class GitRepo(object):
         print(refs)
         # Does tag exist?
         return r_name in refs
-
+        

--- a/git2jss/vcs.py
+++ b/git2jss/vcs.py
@@ -25,8 +25,8 @@ import io
 from git2jss.exceptions import Git2JSSError
 
 
-class TagNotFoundError(Git2JSSError):
-    """ Tag wasn't found """
+class RefNotFoundError(Git2JSSError):
+    """ Ref wasn't found """
     pass
 
 
@@ -51,14 +51,15 @@ class NotAGitRepoError(Git2JSSError):
 
 class GitRepo(object):
     """ Provides a representation of a Git repository at a particular
-        tag, with methods to retrieve files and information.
+        point in time, with methods to retrieve files and information.
     """
 
-    def __init__(self, tag, create=False, sourcedir='.'):
+    def __init__(self, tag=None, branch=None, sourcedir='.'):
         """ Create a GitRepo object which represents the
-        remote repository at state `tag`
+        remote repository at reference `ref`
 
         :param tag: The VCS tag to use to base this object on
+        :param ref: The VCS reference to use to base this object on
         :param create: (optional) Whether to create the tag if it doesn't
             exist
         :param sourcedir: (optional) The local directory from which to
@@ -67,6 +68,13 @@ class GitRepo(object):
         """
 
         self.tag = tag
+        self.branch = branch
+
+        if tag:
+            self.ref = tag
+        else:
+            self.ref = branch
+
         self.sourcedir = sourcedir
         self.tmp_dir = tempfile.mkdtemp()
 
@@ -79,16 +87,12 @@ class GitRepo(object):
 
         self.remote_url = self._find_remote_url()
 
-        if self._has_tag_on_remote(self.tag):
+        if self._has_ref_on_remote(self.ref):
             self._clone_to_tmp()
         else:
-            if not create:
-                raise TagNotFoundError("tag doesn't exist on git remote {}: {}"
-                                       .format(self.remote_url, self.tag))
-            else:
-                self.create_tag()
-                self.__init__(tag)  # pylint: disable=non-parent-init-called
-
+            raise RefNotFoundError("Ref doesn't exist on git remote {}: {}"
+                                       .format(self.remote_url, self.ref))
+                
     def __del__(self):
         """ Called when there are 0 references left to this
         object. try to delete our temporary directory.
@@ -137,31 +141,32 @@ class GitRepo(object):
         return _url
 
     def _clone_to_tmp(self):
-        """ Check out a fresh copy of the `tag` we are going to operate on
-            script_tag must be present on the git remote
+        """ Clone fresh copy of the repo we are going to operate on
+            self.ref must be present on the git remote
         """
         print("Git remote: {}".format(self.remote_url))
         # Use check_output to suppress stdout, which is rather chatty
         # even with '-q'.
         try:
             subprocess.check_output(["git", "clone", "-q", "--branch",
-                                     self.tag, self.remote_url + ".git",
+                                     self.ref, self.remote_url + ".git",
                                      self.tmp_dir], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as err:
             # Don't know what happened!
             raise Git2JSSError(err.output)
         else:
-            print("Checked out tag {}.".format(self.tag))
+            print("Checked out repo at {}.".format(self.ref))
 
-    def create_tag(self, msg='Tagged by Git2jss'):
-        """ Create tag and push to git remote
-        :param msg: (optional) Message to attach to the tag when creating it.
+
+    def _format_commit(self, filename):
+        """ Return a nice-looking string to be the 'version'
+        of a file in this repo.
         """
-        subprocess.check_call(['git', 'tag', '-a', self.tag, '-m', msg],
-                              cwd=self.tmp_dir)
-        subprocess.check_call(['git', 'push', 'origin', self.tag],
-                              cwd=self.tmp_dir)
-        print("Tag {} pushed to git remote".format(self.tag))
+        commit = subprocess.check_output(["git", "log",
+                                          "-1", "--format=%H",
+                                          filename], cwd=self.tmp_dir).strip()
+        
+        return '{} on branch: {}'.format(commit, self.branch)
 
     def file_info(self, filename):
         """ Return a dict of information about `filename`
@@ -170,7 +175,7 @@ class GitRepo(object):
         """
         if self.has_file(filename):
             git_info = {}
-            git_info['VERSION'] = self.tag
+            git_info['VERSION'] = self.tag or self._format_commit(filename)
             git_info['ORIGIN'] = self.remote_url
             git_info['PATH'] = filename
             git_info['DATE'] = subprocess.check_output(["git", "log",
@@ -181,8 +186,8 @@ class GitRepo(object):
                                                        filename], cwd=self.tmp_dir).strip()
             return git_info
         else:
-            raise FileNotFoundError("Couldn't find file {} at tag {}"
-                                    .format(filename, self.tag))
+            raise FileNotFoundError("Couldn't find file {} at ref {}"
+                                    .format(filename, self.ref))
 
     def path_to_file(self, filename):
         """ Return absolute path to `filename` inside
@@ -195,8 +200,8 @@ class GitRepo(object):
         if self.has_file(filename):
             return os.path.abspath(path)
         else:
-            raise FileNotFoundError("Couldn't find file {} at tag {}"
-                                    .format(filename, self.tag))
+            raise FileNotFoundError("Couldn't find file {} at ref {}"
+                                    .format(filename, self.ref))
 
     def has_file(self, filename):
         """ Return True if `filename` exists in this
@@ -215,14 +220,18 @@ class GitRepo(object):
         handle = io.open(self.path_to_file(filename), 'r', encoding="utf-8")
         return handle
 
-    def _has_tag_on_remote(self, tag):
-        """ Check whether `tag` exists in the current repo
+    def _has_ref_on_remote(self, r_name):
+        """ Check whether a reference `r_name` exists in 
+        the current repo 
         :rtype: True or false.
         """
-        # Get tags from the git remote
-        taglist = subprocess.check_output(['git', 'ls-remote', '--tags'],
+        # Get refs from the git remote
+        reflist = subprocess.check_output(['git', 'ls-remote', '--refs'],
                                           cwd=self.sourcedir)
-        # Parse into a list of tags that exist on the git remote
-        tags = [t.split('/')[-1:][0] for t in taglist.split('\n')]
+
+        # Parse into a list of tags and branches that exist on the git remote
+        refs = [t.split('\t')[-1:][0].split('/')[-1:][0] for t in reflist.split('\n')]
+        print(refs)
         # Does tag exist?
-        return tag in tags
+        return r_name in refs
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ values =
 	d
 optional_value = d
 
-[aliases]
-develop = test develop
+#[aliases]
+#develop = test develop
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -19,6 +19,23 @@ def fixture_gitrepo(tmpdir_factory):
                        sourcedir=tmp_dir)
 
 
+@pytest.fixture(scope="session", name="gitrepo_master")
+def fixture_gitrepo_master(tmpdir_factory):
+    """ Return a valid GitRepo object """
+    tmp_dir = str(tmpdir_factory.mktemp('gitrepo'))
+    _build_local_repo(tmp_dir, remote=TEST_REPO)
+    return vcs.GitRepo(branch='master',
+                       sourcedir=tmp_dir)
+
+@pytest.fixture(scope="session", name="gitrepo_branch001")
+def fixture_gitrepo_branch001(tmpdir_factory):
+    """ Return a valid GitRepo object """
+    tmp_dir = str(tmpdir_factory.mktemp('gitrepo'))
+    _build_local_repo(tmp_dir, remote=TEST_REPO)
+    return vcs.GitRepo(branch='branch001',
+                       sourcedir=tmp_dir)
+
+
 def _build_local_repo(test_dir, remote=None):
     """ Build a fresh local git repo.
     if `remote` is specified, add the URL
@@ -66,17 +83,41 @@ def test_new_no_tag_on_remote(tmpdir):
     """ Remote doesn't have our tag """
     _build_local_repo(str(tmpdir),
                       remote=TEST_REPO)
-    with raises(vcs.TagNotFoundError):
+    with raises(vcs.RefNotFoundError):
         vcs.GitRepo(tag='NotATag',
                     sourcedir=str(tmpdir))
 
+def test_new_no_branch_on_remote(tmpdir):
+    """ Remote doesn't have our tag """
+    _build_local_repo(str(tmpdir),
+                      remote=TEST_REPO)
+    with raises(vcs.RefNotFoundError):
+        vcs.GitRepo(branch='NotBranch',
+                    sourcedir=str(tmpdir))
 
-def test_new_ok(gitrepo):
+def test_new_with_tag(gitrepo):
     """ Successfully instantiate a GitRepo """
     # '.git' should have been trimmed from the repo URL
     assert gitrepo.remote_url == TEST_REPO[:-4]
     assert gitrepo.remote_name == "origin"
     assert gitrepo.tag == "test-1.0.0"
+
+
+def test_new_with_master(gitrepo_master):
+    """ Successfully instantiate a GitRepo """
+    # '.git' should have been trimmed from the repo URL
+    assert gitrepo_master.remote_url == TEST_REPO[:-4]
+    assert gitrepo_master.remote_name == "origin"
+    assert gitrepo_master.branch == "master"
+
+
+def test_new_with_branch001(gitrepo_branch001):
+    """ Successfully instantiate a GitRepo """
+    # '.git' should have been trimmed from the repo URL
+    assert gitrepo_branch001.remote_url == TEST_REPO[:-4]
+    assert gitrepo_branch001.remote_name == "origin"
+    assert gitrepo_branch001.branch == "branch001"
+
 
 
 def test_check_path_to_file(gitrepo):
@@ -108,19 +149,19 @@ def test_check_non_file_unicode(gitrepo):
         assert gitrepo.path_to_file(u"kf/dsd/⌨fsd/⌨fs/sd.blah")
 
 
-def test_check_create_tag(gitrepo):
-    """ Check we can create a new tag """
-    # We've already got a nice random string
-    newtag = os.path.basename(gitrepo.tmp_dir)
-    # Poke a new tag
-    oldtag = gitrepo.tag
-    try:
-        gitrepo.tag = newtag
-        assert not gitrepo._has_tag_on_remote(newtag)
-        gitrepo.create_tag(msg="Tagged by pytest")
-        assert gitrepo._has_tag_on_remote(newtag)
-    finally:
-        gitrepo.tag = oldtag
+# def test_check_create_tag(gitrepo):
+#     """ Check we can create a new tag """
+#     # We've already got a nice random string
+#     newtag = os.path.basename(gitrepo.tmp_dir)
+#     # Poke a new tag
+#     oldtag = gitrepo.tag
+#     try:
+#         gitrepo.tag = newtag
+#         assert not gitrepo._has_ref_on_remote(newtag)
+#         gitrepo.create_tag(msg="Tagged by pytest")
+#         assert gitrepo._has_tag_on_remote(newtag)
+#     finally:
+#         gitrepo.tag = oldtag
 
 
 def test_get_file_info(gitrepo):
@@ -133,6 +174,16 @@ def test_get_file_info(gitrepo):
             'LOG': '371a104 - Sat, 17 Mar 2018 09:14:38 +0000 noreply@github.com: \n Initial commit'}
     assert gitrepo.file_info(filename) == info
 
+def test_get_file_info_branch(gitrepo_branch001):
+    """ Test getting the git info for a known file """
+    filename = 'README.md'
+    info = {'ORIGIN': 'https://github.com/gkluoe/git2jss-test',
+            'PATH': '{}'.format(filename),
+            'DATE': '"Fri Apr 5 08:54:43 2019 +0100"',
+            'VERSION': 'd63e87d0e695e3304d2f2a8137b1da9d88587bf4 on branch: branch001',
+            'LOG': ('d63e87d - Fri, 5 Apr 2019 08:54:43 +0100 g.lee@ed.ac.uk: \n Add a test branch\n\n'
+                    '371a104 - Sat, 17 Mar 2018 09:14:38 +0000 noreply@github.com: \n Initial commit')}
+    assert gitrepo_branch001.file_info(filename) == info
 
 def test_get_file_info_notexist(gitrepo):
     """ Get info for a non-existing file """


### PR DESCRIPTION
When --branch is specified, the head of the requested branch will be checked out, and the 'version' for the purposes of templating will be stated as the commit hash of the head of that branch plus the name of the branch.

eg: `d63e87d0e695e3304d2f2a8137b1da9d88587bf4 on branch: branch001`